### PR TITLE
Update test-config.json

### DIFF
--- a/test-config.json
+++ b/test-config.json
@@ -696,7 +696,7 @@
      "playout": [
        [1, 1, 1],  [1, 1, 2],  [1, 1, 3],  
        [2, 1, 1],  [2, 1, 2],  [2, 1, 3],
-       [1, 1, 4],  [1, 1, 5]
+       [1, 1, 4],  [1, 1, 5],  [1, 1, 6]
      ]
   },
   "cfhd_12.5_25_50-local/playback-over-wave-baseline-splice-constraints__splice_main_splice_ad.html": {
@@ -780,7 +780,7 @@
      "playout": [
        [1, 1, 1],  [1, 1, 2],  [1, 1, 3],
        [2, 1, 1],  [2, 1, 2],  [2, 1, 3],
-       [1, 1, 4],  [1, 1, 5]
+       [1, 1, 4],  [1, 1, 5],  [1, 1, 6]
      ]
   },
   "ac4-online/playback-over-wave-baseline-splice-constraints__at3_at4.html": {
@@ -794,7 +794,7 @@
      "playout": [
        [1, 1, 1],  [1, 1, 2],  [1, 1, 3],
        [2, 1, 1],  [2, 1, 2],  [2, 1, 3],
-       [1, 1, 4],  [1, 1, 5]
+       [1, 1, 4],  [1, 1, 5],  [1, 1, 6]
      ]
   },
   "eac3-local/playback-over-wave-baseline-splice-constraints__at3_at4.html": {
@@ -808,7 +808,7 @@
      "playout": [
        [1, 1, 1],  [1, 1, 2],  [1, 1, 3],
        [2, 1, 1],  [2, 1, 2],  [2, 1, 3],
-       [1, 1, 4],  [1, 1, 5]
+       [1, 1, 4],  [1, 1, 5],  [1, 1, 6]
      ]
   },
   "eac3-online/playback-over-wave-baseline-splice-constraints__at3_at4.html": {
@@ -822,7 +822,7 @@
      "playout": [
        [1, 1, 1],  [1, 1, 2],  [1, 1, 3],
        [2, 1, 1],  [2, 1, 2],  [2, 1, 3],
-       [1, 1, 4],  [1, 1, 5]
+       [1, 1, 4],  [1, 1, 5],  [1, 1, 6]
      ]
   }
 }


### PR DESCRIPTION
playout parameters reviewed and corrected for test 9.4
Audio playback should match video playback. playout parameter should be set using video fragments.